### PR TITLE
fix: better error message when using a scoped service outside a scope

### DIFF
--- a/src/scope-context.ts
+++ b/src/scope-context.ts
@@ -55,7 +55,13 @@ const scopeContextAsyncStorage = new AsyncLocalStorage<ScopeContext>();
 scopeContextAsyncStorage.enterWith(new ScopeContext());
 
 export function getCurrentScope() {
-  return scopeContextAsyncStorage.getStore() as ScopeContext;
+  const scopeContext = scopeContextAsyncStorage.getStore();
+
+  if (!scopeContext) {
+    throw new Error("Can't obtain this when not inside a scope. Did you use 'setupScope'?");
+  }
+
+  return scopeContext;
 }
 
 export function setupScope<T>(fn: () => T) {


### PR DESCRIPTION
Currently, when a scoped service is used outside a scope created with `setupScope`, the error message is a TypeError reading a property of undefined. This PR provides a proper error message for this case.